### PR TITLE
Update default configuration

### DIFF
--- a/Deimos-config.ini
+++ b/Deimos-config.ini
@@ -5,6 +5,7 @@ wiz_path =
 use_potions = True
 rich_presence = True
 drop_logging = True
+use_anti_afk = True
 
 [hotkeys]
 x_press = X


### PR DESCRIPTION
The "use_anti_afk" setting was overwritten in the default configuration file in a previous [commit](https://github.com/Slackaduts/Deimos-Wizard101/pull/47/commits/32496e27f16cf79f21148aac4ba36d49e4c331c9#diff-174dbd73fb774cbb1d4b83dbbf04eaa8f24e3e9473ba700b4e0ee4f477fc5bd6). This causes issues with users attempting configure it, as it gets removed when checking for erroneous options. Adding it back resolves this conflict.