### PR TITLE
Custom Drop Logging

### DIFF
--- a/Deimos.py
+++ b/Deimos.py
@@ -1588,9 +1588,6 @@ async def main():
 
 							case deimosgui.GUICommandType.KillBot:
 								if bot_task is not None and not bot_task.cancelled():
-									# if 'matched_drop_logging_loop_task' in globals() and not matched_drop_logging_loop_task.cancelled():
-									# 	matched_drop_logging_loop_task.cancel()
-									# await asyncio.sleep(0)
 									bot_task.cancel()
 									logger.debug('Bot Killed')
 									bot_task = None

--- a/src/deimosgui.py
+++ b/src/deimosgui.py
@@ -38,6 +38,8 @@ class GUICommandType(Enum):
 	KillFlythrough = auto()
 
 	ExecuteBot = auto()
+	Match_Drop_CheckBox = auto()
+	Match_Drop_List = auto()
 	KillBot = auto()
 
 	SetPlaystyles = auto()
@@ -102,6 +104,9 @@ class GUIKeys:
 	button_kill_bot = "buttonkillbot"
 	button_set_playstyles = "buttonsetplaystyles"
 	button_set_scale = "buttonsetscale"
+
+	button_drop_setter = "buttondropsetter"
+	button_drop_resetter = "buttondropresetter"
 
 
 class GUICommand:
@@ -192,6 +197,8 @@ def create_gui(gui_theme, gui_text_color, gui_button_color, tool_name, tool_vers
 	framed_utils_layout = gui.Frame(tl('Utils'), utils_layout, title_color=gui_text_color)
 
 	dev_utils_notice = tl('The utils below are for advanced users and no support will be given on them.')
+
+	dev_match_drop_notice = tl('Specify what drops you want to be logged.')
 
 	custom_tp_layout = [
 		[gui.Text(dev_utils_notice, text_color=gui_text_color)],
@@ -345,10 +352,20 @@ def create_gui(gui_theme, gui_text_color, gui_button_color, tool_name, tool_vers
 			gui.Text(tl('Scale') + ':', text_color=gui_text_color), gui.InputText(size=(8, 1), key='scale'),
 			hotkey_button(tl('Set Scale'), GUIKeys.button_set_scale)
 		],
-		[gui.Text('Select a pet world:', text_color=gui_text_color), gui.Combo(['WizardCity', 'Krokotopia', 'Marleybone', 'Mooshu', 'Dragonspyre'], default_value='WizardCity', readonly=True,text_color=gui_text_color, size=(13, 1), key='PetWorldInput')], #, hotkey_button('Set Auto Pet World', True) 
+		[gui.Text('Select a pet world:', text_color=gui_text_color), gui.Combo(['WizardCity', 'Krokotopia', 'Marleybone', 'Mooshu', 'Dragonspyre'], default_value='WizardCity', readonly=True,text_color=gui_text_color, size=(13, 1), key='PetWorldInput')], #, hotkey_button('Set Auto Pet World', True)
 	]
 
 	framed_misc_utils_layout = gui.Frame(tl('Misc Utils'), misc_utils_layout, title_color=gui_text_color)
+
+	drop_layout = [
+		[gui.Text(dev_match_drop_notice, text_color=gui_text_color)],
+		[gui.Multiline(key='match_drops', size=(66, 6), text_color=gui_text_color, horizontal_scroll=True)],
+		[	gui.Button(tl('Set'), key=GUIKeys.button_drop_setter, button_color=(gui_text_color, gui_button_color)),
+			gui.Button(tl('Reset'), key=GUIKeys.button_drop_resetter, button_color=(gui_text_color, gui_button_color)),
+		],
+	]
+
+	framed_drop_layout = gui.Frame(tl('Drop Log Settings'), drop_layout, title_color=gui_text_color)
 
 	tabs = [
 		[
@@ -359,7 +376,7 @@ def create_gui(gui_theme, gui_text_color, gui_button_color, tool_name, tool_vers
 			gui.Tab(tl('Flythrough'), [[framed_flythrough_layout]], title_color=gui_text_color),
 			gui.Tab(tl('Bot'), [[framed_bot_creator_layout]], title_color=gui_text_color),
 			gui.Tab(tl('Combat'), [[framed_combat_config_layout]], title_color=gui_text_color),
-			gui.Tab(tl('Misc'), [[framed_misc_utils_layout]], title_color=gui_text_color)
+			gui.Tab(tl('Misc'), [[framed_misc_utils_layout], [framed_drop_layout]], title_color=gui_text_color)
 		]
 	]
 
@@ -510,6 +527,16 @@ def manage_gui(send_queue: queue.Queue, recv_queue: queue.Queue, gui_theme, gui_
 
 			case GUIKeys.button_kill_flythrough:
 				send_queue.put(GUICommand(GUICommandType.KillFlythrough))
+
+			case GUIKeys.button_drop_setter:
+				send_queue.put(GUICommand(GUICommandType.Match_Drop_List, inputs['match_drops']))
+				send_queue.put(GUICommand(GUICommandType.Match_Drop_CheckBox, True))
+
+			case GUIKeys.button_drop_resetter:
+				inputs['match_drops'] = ""
+				window['match_drops'].update('')
+				send_queue.put(GUICommand(GUICommandType.Match_Drop_List, inputs['match_drops']))
+				send_queue.put(GUICommand(GUICommandType.Match_Drop_CheckBox, False))
 
 			case GUIKeys.button_run_bot:
 				send_queue.put(GUICommand(GUICommandType.ExecuteBot, inputs['bot_creator']))

--- a/src/drop_logger.py
+++ b/src/drop_logger.py
@@ -44,65 +44,84 @@ async def get_chat(client: Client) -> str:
 
 def filter_drops(input_list: List[str]) -> List[str]:
     # Takes in a list of chat window text and only returns the item drops.
-    drops = []
+        drops = []
+        for raw_i in input_list.copy():
+            # Ensures this message came from the system and not another player, it's safe to assume no player will ever say this
+            if 'Art_Chat_System.dds' in raw_i:
+                # Matches everything after "> <"
+                i = re.findall('(?<=> <).*|$', raw_i)[0]
 
-    for raw_i in input_list.copy():
-        # Ensures this message came from the system and not another player, it's safe to assume no player will ever say this
-        if 'Art_Chat_System.dds' in raw_i:
-            # Matches everything after "> <"
-            i = re.findall('(?<=> <).*|$', raw_i)[0]
+                if i:
+                    # Matches everything after ; and before >, excluding both
+                    if ';' in i:
+                        drop_type: str = re.findall('(?<=;).*?[^>]*|$', i)[0]
 
-            if i:
-                # Matches everything after ; and before >, excluding both
-                if ';' in i:
-                    drop_type: str = re.findall('(?<=;).*?[^>]*|$', i)[0]
+                    if drop_type in drop_types:
+                        # Match everything in between > <
+                        raw_drop: str = re.findall('>.*?<|$', i)[0]
+                        # Remove arrow brackets
+                        drop: str = re.findall('[^>]+[^<]+|$', raw_drop)[0]
+                        drop = drop.replace(' ', '', 1)
+                        drops.append(drop)
 
-                if drop_type in drop_types:
-                    # Match everything in between > <
-                    raw_drop: str = re.findall('>.*?<|$', i)[0]
-                    # Remove arrow brackets
-                    drop: str = re.findall('[^>]+[^<]+|$', raw_drop)[0]
+                elif ':' in raw_i.lower():
+                    # Matches everything after : and before >, excluding both
+                    drop: str = re.findall('(?<=:).*?[^<]*|$', raw_i)[0]
                     drop = drop.replace(' ', '', 1)
                     drops.append(drop)
+        return drops
 
-            elif ':' in raw_i.lower():
-                # Matches everything after : and before >, excluding both
-                drop: str = re.findall('(?<=:).*?[^<]*|$', raw_i)[0]
-                drop = drop.replace(' ', '', 1)
-                drops.append(drop)
+def stuff_finder(A, B):
+    for item in A:
+        if item in B:
+            index = B.index(item)
+            B = B[index + 1:]
+    return B
 
-    return drops
+##### OLD FUNCTION #####
 
+# def find_new_stuff(old: str, new: str) -> str:
+#     # CREDIT TO SIROLAF FOR THIS FUNCTION
+# 	found_idx = -1
 
-def find_new_stuff(old: str, new: str) -> str:
-    # CREDIT TO SIROLAF FOR THIS FUNCTION
-	found_idx = -1
+# 	while True:
+# 		found_idx = new.find(old)
+# 		if found_idx >= 0:
+# 			break
+# 		old = old[1:]
+# 		if len(old) == 0:
+# 			break
 
-	while True:
-		found_idx = new.find(old)
-		if found_idx >= 0:
-			break
-		old = old[1:]
-		if len(old) == 0:
-			break
+# 	if found_idx < 0:
+# 		return new # entire string is new
+# 	return new[found_idx+len(old):]
 
-	if found_idx < 0:
-		return new # entire string is new
-	return new[found_idx+len(old):]
-
-
-async def logging_loop(client: Client):
+async def logging_loop(client: Client, toSearch=[]):
     # TODO: Finish this loop and create a system for determining new drops
+    if toSearch:
+        toSearch = toSearch.split('\n')
     while True:
+        chat_text = await get_chat(client)
         await asyncio.sleep(1)
 
-        chat_text = await get_chat(client)
         if chat_text:
             temp_drops = filter_drops(chat_text.split('\n'))
-            new_drops = find_new_stuff(client.latest_drops, '\n'.join(temp_drops))
+            new_drops = stuff_finder(client.latest_drops.split('\n'), temp_drops)
+
             if not client.latest_drops:
                 client.latest_drops = '\n'.join(temp_drops)
-
+            
             elif new_drops:
-                client.latest_drops = '\n'.join(temp_drops)
-                [logger.debug(f'{client.title} - New Drop: {drop}') for drop in new_drops.split('\n')[1:]]
+                # If custom drop logging is provided
+                if toSearch:
+                     new_drops_set = set(new_drops)
+                     toSearch_set = set(toSearch)
+                     new_drops_set = new_drops_set.intersection(toSearch_set)
+                     client.latest_drops = '\n'.join(temp_drops)
+                     for drop in new_drops_set:
+                        logger.debug(f'{client.title} - Recorded Drop: {drop}')
+                # If no custom drop logging is provided
+                else:
+                    client.latest_drops = '\n'.join(temp_drops)
+                    for drop in new_drops:
+                        logger.debug(f'{client.title} - New Drop: {drop}')

--- a/src/drop_logger.py
+++ b/src/drop_logger.py
@@ -113,7 +113,7 @@ async def logging_loop(client: Client, toSearch=[]):
             
             elif new_drops:
                 # If custom drop logging is provided
-                if toSearch:
+                if len(toSearch) > 0:
                      new_drops_set = set(new_drops)
                      toSearch_set = set(toSearch)
                      new_drops_set = new_drops_set.intersection(toSearch_set)


### PR DESCRIPTION
Added option to set custom items logging in drop log. The setting is available in Misc tab and requires users to type full names of items on each line, after setting it the console will only log those items and ignore any others from the drop. The reset button switches back to the default drop logging every drop.